### PR TITLE
rename edit plant

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {NavigationContainer} from '@react-navigation/native';
 import {createStackNavigator} from '@react-navigation/stack';
 import {HomeScreen} from './screens/Home/HomeScreen';
-import {PlantChoiceScreen} from './screens/PlantChoice/PlantChoiceScreen';
+import {EditPlantScreen} from './screens/EditPlant/EditPlant';
 import {RecoilRoot} from 'recoil';
 
 const Stack = createStackNavigator();
@@ -13,7 +13,7 @@ export function App() {
       <NavigationContainer>
         <Stack.Navigator>
           <Stack.Screen name="Home" component={HomeScreen} />
-          <Stack.Screen name="PlantChoice" component={PlantChoiceScreen} />
+          <Stack.Screen name="EditPlant" component={EditPlantScreen} />
         </Stack.Navigator>
       </NavigationContainer>
     </RecoilRoot>

--- a/src/screens/EditPlant/EditPlant.tsx
+++ b/src/screens/EditPlant/EditPlant.tsx
@@ -15,10 +15,7 @@ import type {
 } from '../../utils/types';
 import {useAddPlant, useSpeciesArr} from '../../utils/state';
 
-export function PlantChoiceScreen({
-  navigation,
-  route,
-}: ScreenProp<'PlantChoice'>) {
+export function EditPlantScreen({navigation, route}: ScreenProp<'EditPlant'>) {
   const {contact} = route.params;
   const speciesArr = useSpeciesArr();
   const [speciesId, setSpeciesId] = useState<SpeciesId | undefined>(undefined);

--- a/src/screens/Home/HomeScreen.tsx
+++ b/src/screens/Home/HomeScreen.tsx
@@ -16,7 +16,7 @@ export function HomeScreen({navigation}: ScreenProp<'Home'>) {
   async function pickContact() {
     const contact = await selectContactLib.selectContact();
     if (contact) {
-      navigation.navigate('PlantChoice', {
+      navigation.navigate('EditPlant', {
         contact,
       });
     } else {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -62,7 +62,7 @@ export type WaterFrequency = Readonly<{
 
 type RootStackParamList = Readonly<{
   Home: undefined;
-  PlantChoice: {
+  EditPlant: {
     contact: Contact;
   };
 }>;


### PR DESCRIPTION
Because it's not really a screen for
choosing a plant, it's a screen for
*creating* a plant once the contact
has already been selected.

We will probably be able to reuse it
for editing, so calling it "EditPlant"