### PR TITLE
Save new state to async storage, not old state

### DIFF
--- a/__tests__/add-plants-test.tsx
+++ b/__tests__/add-plants-test.tsx
@@ -126,6 +126,22 @@ test('add plants', async () => {
             "unit": "days",
           },
         },
+        Object {
+          "contact": Object {
+            "emails": Array [],
+            "name": "Ms. Pacman",
+            "phones": Array [],
+            "postalAddresses": Array [],
+            "recordId": "record3",
+          },
+          "lastWatered": "2020-02-02T10:49:41.836Z",
+          "plantId": "3",
+          "speciesId": "3",
+          "waterFrequency": Object {
+            "number": 1,
+            "unit": "months",
+          },
+        },
       ]
     `);
   }

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -140,8 +140,9 @@ export function useAddPlant() {
       speciesId,
       waterFrequency,
     });
-    setPlants([...plants, plant]);
-    storePlantsToAsyncStorage(plants);
+    const newPlants = [...plants, plant];
+    setPlants(newPlants);
+    storePlantsToAsyncStorage(newPlants);
   }
 
   return addPlant;


### PR DESCRIPTION
fix bug where adding a plant and then restarting
the app would not show the most recently added
plant.