### PR TITLE
enable editing plants

### DIFF
--- a/__tests__/plant-screen-test.tsx
+++ b/__tests__/plant-screen-test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import {
+  fireEvent,
+  render,
+  RenderAPI,
+  within,
+} from '@testing-library/react-native';
+import {App} from '../src/App';
+import type {WaterFrequency} from '../src/utils/types';
+import {
+  mockNowDate,
+  plantTestInstanceToString,
+  setPlantOptions,
+  STARTER_PLANTS_STATE,
+} from '../test-util/test-util';
+import {getPlantsFromHomeScreen} from '../test-util/test-util';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+test('edit plants', async () => {
+  mockNowDate(new Date('2020-01-01T10:49:41.836Z'));
+  await AsyncStorage.setItem(
+    'plantsState',
+    JSON.stringify(STARTER_PLANTS_STATE),
+  );
+
+  const r = render(<App />);
+  await editPlant(r, 'Professor Professorson', {
+    speciesName: 'Circle Tree',
+    waterFrequency: {
+      number: 5,
+      unit: 'weeks',
+    },
+  });
+
+  const plantScreen = await r.findByTestId('PlantScreen');
+  const plantView = await within(plantScreen).findByA11yLabel(
+    /Professor Professorson the plant/,
+  );
+  const plantStr = plantTestInstanceToString(plantView);
+  expect(plantStr).toMatch(/🌳 Professor Professorson/)
+  expect(JSON.parse((await AsyncStorage.getItem('plantsState'))!))
+    .toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "contact": Object {
+          "emails": Array [],
+          "name": "Professor Professorson",
+          "phones": Array [],
+          "postalAddresses": Array [],
+          "recordId": "record1",
+        },
+        "lastWatered": "2020-01-01T10:49:41.836Z",
+        "plantId": "1",
+        "speciesId": "2",
+        "waterFrequency": Object {
+          "number": 5,
+          "unit": "weeks",
+        },
+      },
+      Object {
+        "contact": Object {
+          "emails": Array [],
+          "name": "Person McPherson",
+          "phones": Array [],
+          "postalAddresses": Array [],
+          "recordId": "record2",
+        },
+        "lastWatered": "2020-01-01T10:49:41.836Z",
+        "plantId": "2",
+        "speciesId": "7",
+        "waterFrequency": Object {
+          "number": 4,
+          "unit": "days",
+        },
+      },
+    ]
+  `);
+});
+
+export async function editPlant(
+  r: RenderAPI,
+  plantName: string,
+  {
+    speciesName,
+    waterFrequency,
+  }: {speciesName: string; waterFrequency: WaterFrequency},
+): Promise<void> {
+  const plants = await getPlantsFromHomeScreen(r);
+  const plantsAsTest = plants.map(plantTestInstanceToString);
+  const index = plantsAsTest.findIndex((p) => p.includes(plantName));
+  if (index === -1) {
+    throw Error(`could not find rendered plant matching ${plantName}`);
+  }
+  if (plantsAsTest[index].includes(speciesName)) {
+    throw Error('Bad test design: speciesName would not change');
+  }
+
+  const plantScreenButton = await r.findByA11yLabel(
+    `Go to plant screen for plant ${plantName}`,
+  );
+  fireEvent(plantScreenButton, 'onPress');
+  const editButton = await r.findByA11yLabel(`Edit plant ${plantName}`);
+  fireEvent(editButton, 'onPress');
+  return setPlantOptions(r, speciesName, waterFrequency);
+}

--- a/__tests__/plant-screen-test.tsx
+++ b/__tests__/plant-screen-test.tsx
@@ -37,7 +37,7 @@ test('edit plants', async () => {
     /Professor Professorson the plant/,
   );
   const plantStr = plantTestInstanceToString(plantView);
-  expect(plantStr).toMatch(/🌳 Professor Professorson/)
+  expect(plantStr).toMatch(/🌳 Professor Professorson/);
   expect(JSON.parse((await AsyncStorage.getItem('plantsState'))!))
     .toMatchInlineSnapshot(`
     Array [
@@ -86,13 +86,16 @@ export async function editPlant(
   }: {speciesName: string; waterFrequency: WaterFrequency},
 ): Promise<void> {
   const plants = await getPlantsFromHomeScreen(r);
-  const plantsAsTest = plants.map(plantTestInstanceToString);
-  const index = plantsAsTest.findIndex((p) => p.includes(plantName));
-  if (index === -1) {
-    throw Error(`could not find rendered plant matching ${plantName}`);
-  }
-  if (plantsAsTest[index].includes(speciesName)) {
-    throw Error('Bad test design: speciesName would not change');
+  {
+    const plantText = plants
+      .map(plantTestInstanceToString)
+      .find((p) => p.includes(plantName));
+    if (plantText === undefined) {
+      throw Error(`could not find rendered plant matching ${plantName}`);
+    }
+    if (plantText.includes(speciesName)) {
+      throw Error('Bad test design: speciesName would not change');
+    }
   }
 
   const plantScreenButton = await r.findByA11yLabel(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import {createStackNavigator} from '@react-navigation/stack';
 import {HomeScreen} from './screens/Home/HomeScreen';
 import {PlantChoiceScreen} from './screens/PlantChoice/PlantChoiceScreen';
 import {RecoilRoot} from 'recoil';
+import {PlantScreen} from './screens/Plant/PlantScreen';
 
 const Stack = createStackNavigator();
 
@@ -14,6 +15,7 @@ export function App() {
         <Stack.Navigator>
           <Stack.Screen name="Home" component={HomeScreen} />
           <Stack.Screen name="PlantChoice" component={PlantChoiceScreen} />
+          <Stack.Screen name="Plant" component={PlantScreen} />
         </Stack.Navigator>
       </NavigationContainer>
     </RecoilRoot>

--- a/src/components/PlantView.tsx
+++ b/src/components/PlantView.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import {View, Text} from 'react-native';
+import type {UIPlant} from '../utils/types';
+import {formatDay} from '../utils/date';
+
+export function PlantView({plant}: {plant: UIPlant}) {
+  // Harmless side effect we don't need to live-update the days
+  // and we can mock Date.now in tests
+  const now = new Date(Date.now());
+  const {name} = plant.contact;
+  return (
+    <View accessible accessibilityLabel={`${name} the plant`}>
+      <Text>
+        {plant.appearance.emoji} {name} ({plant.state})
+      </Text>
+      <Text>last watered: {formatDay(now, plant.lastWatered)} </Text>
+      <Text>next watering: {formatDay(now, plant.nextWatering)}</Text>
+    </View>
+  );
+}

--- a/src/screens/Plant/PlantScreen.tsx
+++ b/src/screens/Plant/PlantScreen.tsx
@@ -1,0 +1,52 @@
+/**
+ * This screen requires a contact,
+ * and enables the user to select plant attributes
+ * (such as species and watering frequency)
+ */
+import React from 'react';
+import {Button, Text, View} from 'react-native';
+import type {ScreenProp} from '../../utils/types';
+import {useUIPlant} from '../../utils/state';
+import {PlantView} from '../../components/PlantView';
+
+export function PlantScreen({navigation, route}: ScreenProp<'Plant'>) {
+  const {plantId} = route.params;
+  const plant = useUIPlant(plantId);
+
+  /* istanbul ignore next */
+  if (!plant) {
+    throw Error(`could not find plant with id ${plantId}`);
+  }
+  if (plant === 'loading') {
+    return (
+      <View>
+        <Text>loading</Text>
+      </View>
+    );
+  }
+
+  function edit() {
+    /* istanbul ignore next */
+    if (plant === 'loading') {
+      throw Error(
+        'In impossible state: how could the button be clicked before the plant loaded?',
+      );
+    }
+    navigation.navigate('PlantChoice', {
+      action: 'updatePlant',
+      plantId,
+      contact: plant.contact,
+    });
+  }
+
+  return (
+    <View testID="PlantScreen">
+      <PlantView plant={plant} />
+      <Button
+        accessibilityLabel={`Edit plant ${plant.contact.name}`}
+        title="Edit Plant"
+        onPress={edit}
+      />
+    </View>
+  );
+}

--- a/src/screens/PlantChoice/PlantChoiceScreen.tsx
+++ b/src/screens/PlantChoice/PlantChoiceScreen.tsx
@@ -13,24 +13,38 @@ import type {
   SpeciesId,
   WaterFrequency,
 } from '../../utils/types';
-import {useAddPlant, useSpeciesArr} from '../../utils/state';
+import {useAddPlant, useSpeciesArr, useUpdatePlant} from '../../utils/state';
 
 export function PlantChoiceScreen({
   navigation,
   route,
 }: ScreenProp<'PlantChoice'>) {
-  const {contact} = route.params;
-  const speciesArr = useSpeciesArr();
   const [speciesId, setSpeciesId] = useState<SpeciesId | undefined>(undefined);
+  const speciesArr = useSpeciesArr();
   const addPlant = useAddPlant();
+  const updatePlant = useUpdatePlant();
+  const {contact} = route.params;
 
   function handlePickWaterFrequency(waterFrequency: WaterFrequency): void {
     /* istanbul ignore next */
     if (!speciesId) {
       throw Error('expected speciesId to be defined');
     }
-    addPlant({contact, speciesId: speciesId, waterFrequency});
-    navigation.navigate('Home');
+    const options = {
+      waterFrequency,
+      speciesId,
+    };
+    switch (route.params.action) {
+      case 'addPlant':
+        addPlant(route.params.contact, options);
+        navigation.navigate('Home');
+        break;
+      case 'updatePlant':
+        const {plantId} = route.params;
+        updatePlant(plantId, options);
+        navigation.navigate('Plant', {plantId});
+        break;
+    }
   }
 
   if (speciesId) {

--- a/src/utils/plant-calculations.ts
+++ b/src/utils/plant-calculations.ts
@@ -30,7 +30,7 @@ export function plantToUIPlant(
 
   return {
     plantId,
-    name: contact.name,
+    contact,
     appearance,
     lastWatered,
     nextWatering,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -4,17 +4,20 @@
 import type {StackScreenProps} from '@react-navigation/stack';
 import type {Contact} from 'react-native-select-contact';
 
+export interface PlantOptions {
+  readonly speciesId: SpeciesId;
+  readonly waterFrequency: WaterFrequency;
+}
+
 /**
  * Users can create a plant for one of their contacts,
  * and the app will indicate if they need to "water" the plant
  * (stay in touch with the friend or family member or colleague)
  */
-export interface Plant {
+export interface Plant extends PlantOptions {
   readonly plantId: PlantId;
   readonly contact: Contact;
   readonly lastWatered: Date;
-  readonly waterFrequency: WaterFrequency;
-  readonly speciesId: SpeciesId;
 }
 
 /**
@@ -39,7 +42,7 @@ export interface Species {
  */
 export interface UIPlant {
   readonly plantId: PlantId;
-  readonly name: string;
+  readonly contact: Contact;
   readonly appearance: PlantAppearance;
   readonly lastWatered: Date;
   readonly waterFrequency: WaterFrequency;
@@ -62,8 +65,14 @@ export interface WaterFrequency {
 
 type RootStackParamList = Readonly<{
   Home: undefined;
-  PlantChoice: {
-    contact: Contact;
+  PlantChoice:
+    | {
+        action: 'addPlant';
+        contact: Contact;
+      }
+    | {action: 'updatePlant'; contact: Contact; plantId: PlantId};
+  Plant: {
+    plantId: PlantId;
   };
 }>;
 

--- a/test-util/test-util.ts
+++ b/test-util/test-util.ts
@@ -1,11 +1,16 @@
 /* istanbul ignore file */
 import {Text} from 'react-native';
-import { act, fireEvent, RenderAPI, waitFor, within } from "@testing-library/react-native";
-import type { Contact } from "react-native-select-contact";
-import type { ReactTestInstance } from "react-test-renderer";
+import {
+  act,
+  fireEvent,
+  RenderAPI,
+  waitFor,
+  within,
+} from '@testing-library/react-native';
+import type {Contact} from 'react-native-select-contact';
+import type {ReactTestInstance} from 'react-test-renderer';
 import * as selectContactLib from 'react-native-select-contact';
-import type { WaterFrequency } from "../src/utils/types";
-
+import type {WaterFrequency} from '../src/utils/types';
 
 export interface PlantFixture {
   contact: Contact | null;
@@ -13,7 +18,38 @@ export interface PlantFixture {
   wateringFrequency: WaterFrequency;
 }
 
-export function plantTestInstanceToString(component: ReactTestInstance): string {
+export const STARTER_PLANTS_STATE = [
+  {
+    plantId: '1',
+    contact: {
+      name: 'Professor Professorson',
+      recordId: 'record1',
+      phones: [],
+      emails: [],
+      postalAddresses: [],
+    },
+    speciesId: '1',
+    lastWatered: '2020-01-01T10:49:41.836Z',
+    waterFrequency: {number: 3, unit: 'weeks'},
+  },
+  {
+    plantId: '2',
+    contact: {
+      name: 'Person McPherson',
+      recordId: 'record2',
+      phones: [],
+      emails: [],
+      postalAddresses: [],
+    },
+    speciesId: '7',
+    lastWatered: '2020-01-01T10:49:41.836Z',
+    waterFrequency: {number: 4, unit: 'days'},
+  },
+];
+
+export function plantTestInstanceToString(
+  component: ReactTestInstance,
+): string {
   return within(component)
     .UNSAFE_getAllByType(Text)
     .flatMap((t) => t.props.children)
@@ -24,38 +60,27 @@ export async function getPlantsFromHomeScreen(
   r: RenderAPI,
 ): Promise<ReactTestInstance[]> {
   await waitFor(async () => await r.findByTestId('Plants List'));
-  return r.findAllByTestId(/.+the plant/);
+  return r.findAllByA11yLabel(/.+the plant/);
 }
 
 export function mockNowDate(now: Date) {
   jest.spyOn(global.Date, 'now').mockImplementation(() => now.valueOf());
 }
 
-export async function addPlant(
-  r: RenderAPI,
-  {contact, speciesName, wateringFrequency}: PlantFixture,
-): Promise<void> {
-  jest
-    .spyOn(selectContactLib, 'selectContact')
-    .mockImplementation(async () => contact);
-  const addPlantButton = await r.findByA11yLabel('Add Plant');
-  fireEvent(addPlantButton, 'onPress');
-  const speciesButtons = await waitFor(
-    async () => await r.findAllByA11yLabel(/Press to select species/),
-  );
-  const cactusButton = speciesButtons.find((b) =>
-    b.props.accessibilityLabel.includes(speciesName),
-  );
-  expect(cactusButton).toBeDefined();
-  if (!cactusButton) {
-    throw Error('expected cactusButton to be defined');
-  }
 
-  fireEvent(cactusButton, 'onPress');
+export async function setPlantOptions(
+  r: RenderAPI,
+  speciesName: string,
+  waterFrequency: WaterFrequency
+) {
+  const speciesButton = await r.findByA11yLabel(`Press to select species ${speciesName}`)
+  fireEvent(speciesButton, 'onPress');
   const wateringPicker = await waitFor(
     async () => await r.findByA11yLabel('Select how often to water'),
   );
   // Note: We are bypassing the `Picker` components
   // https://github.com/callstack/react-native-testing-library/issues/500
-  act(() => wateringPicker.parent!.parent!.props.onPick(wateringFrequency));
+  act(() => {
+    wateringPicker.parent!.parent!.props.onPick(waterFrequency);
+  })
 }


### PR DESCRIPTION
close #15

## Description

Tap a plant on the main screen to get to the "Plant" screen.

This screen has a button for editing the plant. We can also add buttons here in future for:
- watering (calling)
- removing

Tap "Edit Plant" to update the species and/or watering frequency.

## Notes

Note: I wasn't sure what to call the new test file–ideas welcome. `plant-screen-test.tsx` may not fit with our current conventions.

This PR also includes refactors:
- extract part of HomeScreen into a PlantView component. This is now shared between the Plant screen and the Home screen. In future, we ma want to display these slightly differently, but was convenient for this PR.
- change the `addPlant` test util to `setPlantOptions`. This is shared code for setting watering frequency and species, it is used by both `add-plants-test.tsx` and `plants-screen-test.tsx`.
- the test 'get items from async storage' is now deterministic - we now mock the date.
